### PR TITLE
bug fix. rename function

### DIFF
--- a/autoload/ac_smooth_scroll.vim
+++ b/autoload/ac_smooth_scroll.vim
@@ -36,16 +36,16 @@ function! s:calc_step(wlcount)
   if !g:ac_smooth_scroll_enable_accelerating
     return 1
   endif
-  let step = g:ac_smooth_scroll_calc_step(s:key_count, a:wlcount)
+  let step = AcSmoothScrollCalcStep(s:key_count, a:wlcount)
   return step
 endfunction
 
 function! s:calc_sleep_time_msec(sleep_time_msec)
-  return g:ac_smooth_scroll_calc_sleep_time_msec(s:key_count, a:sleep_time_msec)
+  return AcSmoothScrollCalcSleepTimeMsec(s:key_count, a:sleep_time_msec)
 endfunction
 
 function! s:calc_skip_redraw_line_size()
-  return g:ac_smooth_scroll_calc_skip_redraw_line_size(s:key_count, g:ac_smooth_scroll_skip_redraw_line_size)
+  return AcSmoothScrollCalcSkipRedrawLineSize(s:key_count, g:ac_smooth_scroll_skip_redraw_line_size)
 endfunction
 
 function! s:next_line_num(cmd, lnum, step)

--- a/doc/accelerated-smooth-scroll.jax
+++ b/doc/accelerated-smooth-scroll.jax
@@ -152,13 +152,13 @@ FUNCTIONS                                 *accelerated-smooth-scroll-functions*
 以下関数をOverrideすることで、スクロールの加速度を微調整することができます。
 (この関数の使用は、将来変更される可能性があります)
 
-g:ac_smooth_scroll_calc_step(key_count, wlcount)                       *g:ac_smooth_scroll_calc_step*
+AcSmoothScrollCalcStep(key_count, wlcount)                       *AcSmoothScrollCalcStep*
     一度にスクロールするステップ数を取得する。
 
     key_count : キーを押した回数 (<C-d>/<C-u> or <C-F>/<C-B>)
     wlcount   : 全体で移動する行数 (半ページ or 1ページの行数)
 
-g:ac_smooth_scroll_calc_sleep_time_msec(key_count, sleep_time_msec)    *g:ac_smooth_scroll_calc_sleep_time_msec*
+AcSmoothScrollCalcSleepTimeMsec(key_count, sleep_time_msec)    *AcSmoothScrollCalcSleepTimeMsec*
     ステップ数スクロール後のスリープ時間を取得する。
 
     key_count       : キーを押した回数 (<C-d>/<C-u> or <C-F>/<C-B>)

--- a/doc/accelerated-smooth-scroll.txt
+++ b/doc/accelerated-smooth-scroll.txt
@@ -146,13 +146,13 @@ FUNCTIONS                                 *accelerated-smooth-scroll-functions*
 You can use the following functions to change scroll acceleration.
 Note that the specifications of these functions may change in the future.
 
-g:ac_smooth_scroll_calc_step(key_count, wlcount)                       *g:ac_smooth_scroll_calc_step*
+AcSmoothScrollCalcStep(key_count, wlcount)                       *AcSmoothScrollCalcStep*
     Calculate the step count.
 
     key_count : Input key count (<C-d>/<C-u> or <C-F>/<C-B>)
     wlcount   : Total line count to move (half page or a page line count)
 
-g:ac_smooth_scroll_calc_sleep_time_msec(key_count, sleep_time_msec)    *g:ac_smooth_scroll_calc_sleep_time_msec*
+AcSmoothScrollCalcSleepTimeMsec(key_count, sleep_time_msec)    *AcSmoothScrollCalcSleepTimeMsec*
     Calculate the sleep time.
 
     key_count       : Input key count (<C-d>/<C-u> or <C-F>/<C-B>)

--- a/plugin/ac_smooth_scroll.vim
+++ b/plugin/ac_smooth_scroll.vim
@@ -20,8 +20,8 @@ let g:ac_smooth_scroll_skip_redraw_line_size = get(g:, 'ac_smooth_scroll_skip_re
 let g:ac_smooth_scroll_min_limit_msec = get(g:, 'ac_smooth_scroll_min_limit_msec', 50)
 let g:ac_smooth_scroll_max_limit_msec = get(g:, 'ac_smooth_scroll_max_limit_msec', 300)
 
-if !exists('*g:ac_smooth_scroll_calc_step')
-  function! g:ac_smooth_scroll_calc_step(key_count, wlcount)
+if !exists('*AcSmoothScrollCalcStep')
+  function! AcSmoothScrollCalcStep(key_count, wlcount)
     if a:key_count > a:wlcount / 2
       return a:wlcount
     endif
@@ -29,14 +29,14 @@ if !exists('*g:ac_smooth_scroll_calc_step')
   endfunction
 endif
 
-if !exists('*g:ac_smooth_scroll_calc_sleep_time_msec')
-  function! g:ac_smooth_scroll_calc_sleep_time_msec(key_count, sleep_time_msec)
+if !exists('*AcSmoothScrollCalcSleepTimeMsec')
+  function! AcSmoothScrollCalcSleepTimeMsec(key_count, sleep_time_msec)
     return  a:sleep_time_msec - (a:key_count - 1)
   endfunction
 endif
 
-if !exists('*g:ac_smooth_scroll_calc_skip_redraw_line_size')
-  function! g:ac_smooth_scroll_calc_skip_redraw_line_size(key_count, skip_redraw_line_size)
+if !exists('*AcSmoothScrollCalcSkipRedrawLineSize')
+  function! AcSmoothScrollCalcSkipRedrawLineSize(key_count, skip_redraw_line_size)
     " return  a:skip_redraw_line_size + (a:key_count - 1)
     return a:skip_redraw_line_size
   endfunction


### PR DESCRIPTION
Vim 7.4.260 では、`g:hogehoge` のような形で関数を宣言できません。
そのため、グローバル関数をUpperCamelCaseにしました。
